### PR TITLE
FolderCreateのエラー判定の処理の変更

### DIFF
--- a/driveRecordIOS/folderCreateViewController.swift
+++ b/driveRecordIOS/folderCreateViewController.swift
@@ -305,14 +305,23 @@ class FolderCreateViewController : UIViewController, UITextFieldDelegate {
             alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
             present(alert, animated: true, completion: nil)
             return false
-        // メンバーが一人でも入力されているかチェック
+            // メンバーが一人でも入力されているかチェック
         } else if travelMember1.isEmpty {
-            let alert = UIAlertController(title: "エラー",
-                                          message: "メンバー名を入力してください",
-                                          preferredStyle: UIAlertController.Style.alert)
-            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-            present(alert, animated: true, completion: nil)
-            return false
+            if travelMember2.isEmpty && travelMember3.isEmpty && travelMember3.isEmpty && travelMember4.isEmpty && travelMember5.isEmpty && travelMember6.isEmpty  {
+                let alert = UIAlertController(title: "エラー",
+                                              message: "メンバー名を入力してください",
+                                              preferredStyle: UIAlertController.Style.alert)
+                alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+                present(alert, animated: true, completion: nil)
+                return false
+            } else {
+                let alert = UIAlertController(title: "エラー",
+                                              message: "一番上からメンバー名を入力してください",
+                                              preferredStyle: UIAlertController.Style.alert)
+                alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+                present(alert, animated: true, completion: nil)
+                return false
+            }
         } else {
             
             // データベース接続


### PR DESCRIPTION
フォルダ作成時に、メンバーを１番上からではなく２番目以降に入力した場合に「１番上から入力して下さい」とアラートを出す様に変更
全部未入力の場合には、変わらず「メンバーを入力してくだしさい」と出力