### PR TITLE
文字とヘッダーの色変更

### DIFF
--- a/driveRecordIOS/Base.lproj/Main.storyboard
+++ b/driveRecordIOS/Base.lproj/Main.storyboard
@@ -152,13 +152,18 @@
                                 <rect key="frame" x="20" y="8.5" width="39" height="27"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="27"/>
-                                <state key="normal" image="plus" catalog="system" backgroundImage="folder.fill.badge.plus"/>
+                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <state key="normal" image="plus" catalog="system" backgroundImage="folder.fill.badge.plus">
+                                    <color key="titleShadowColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
                                 <connections>
                                     <segue destination="mnq-GX-YY1" kind="presentation" modalPresentationStyle="fullScreen" id="EfS-yr-SXb"/>
                                 </connections>
                             </button>
+                            <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" title="サポート" image="gearshape.fill" catalog="system" id="ZAD-kO-WfL">
+                            <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <connections>
                                 <segue destination="i3W-XZ-F6R" kind="show" id="ESq-mf-J6m"/>
                             </connections>

--- a/driveRecordIOS/Map.storyboard
+++ b/driveRecordIOS/Map.storyboard
@@ -21,10 +21,11 @@
                     </view>
                     <navigationItem key="navigationItem" title="地図" id="0K6-fv-orI">
                         <barButtonItem key="leftBarButtonItem" style="plain" id="vdV-cs-Vfq">
-                            <button key="customView" opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="JJJ-R0-05G">
-                                <rect key="frame" x="20" y="0.0" width="59" height="22"/>
+                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="JJJ-R0-05G">
+                                <rect key="frame" x="20" y="11" width="59" height="22"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="戻る" image="delete.left.fill" catalog="system"/>
+                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <state key="normal" image="delete.left.fill" catalog="system"/>
                                 <connections>
                                     <segue destination="GjR-Ng-jeF" kind="presentation" modalPresentationStyle="fullScreen" id="YOk-Sp-lHI"/>
                                 </connections>

--- a/driveRecordIOS/MapViewController.swift
+++ b/driveRecordIOS/MapViewController.swift
@@ -32,6 +32,8 @@ class MapViewController: UIViewController, CLLocationManagerDelegate {
         
         // Tabバーの色の指定
         self.navigationController!.navigationBar.barTintColor = UIColor.systemTeal
+        // Tabバーの文字の色の指定
+        self.navigationController?.navigationBar.titleTextAttributes = [ .foregroundColor: UIColor.white]
         
         setupMap()
         requestLoacion()

--- a/driveRecordIOS/ViewController.swift
+++ b/driveRecordIOS/ViewController.swift
@@ -22,7 +22,9 @@ class ViewController:UIViewController, UITableViewDelegate, UITableViewDataSourc
         
         // Tabバーの色の指定
         self.navigationController!.navigationBar.barTintColor = UIColor.systemTeal
-        
+        UINavigationBar.appearance().barTintColor = UIColor.systemTeal
+        // Tabバーの文字の色の指定
+        self.navigationController?.navigationBar.titleTextAttributes = [ .foregroundColor: UIColor.white]
         // Table Viewの背面を透過させる処理
         let tblBackColor: UIColor = UIColor.clear
             tableView.backgroundColor = tblBackColor


### PR DESCRIPTION
ホーム画面と地図画面のヘッダー部分の文字の色を黒から白に変更
地図画面の戻るボタンに戻るが記載されていたのを削除