### PR TITLE
金額入力画面から詳細画面に遷移できない点を修正

### DIFF
--- a/driveRecordIOS/MoneyInsertViewController.swift
+++ b/driveRecordIOS/MoneyInsertViewController.swift
@@ -235,10 +235,10 @@ class MoneyInsertViewController : UIViewController, UIPickerViewDelegate, UIPick
         if segue.identifier == "showDetailSegue" {
             
             // 遷移先ViewCntrollerの取得
-            let nextVC  = segue.destination as! FolderDetailViewController
-            
+            let nextVC = segue.destination as! UINavigationController
+            let secondView = nextVC.topViewController as! FolderDetailViewController
             // 値の設定　FolderCreateから送信された値を活用
-            nextVC.receiveId = receiveId
+            secondView.receiveId = receiveId
             
         } else if segue.identifier == "photoConfirm" {
             let nc = segue.destination as! cameraViewController


### PR DESCRIPTION
詳細画面がナビゲーションコントローラーを設置したため、遷移できていなかった
UINavigationControllerのインスタンスを取得するコードに変更することで解決